### PR TITLE
Update DoublePowerAction.java

### DIFF
--- a/whoareyou/src/main/java/questionableDecisions/actions/DoublePowerAction.java
+++ b/whoareyou/src/main/java/questionableDecisions/actions/DoublePowerAction.java
@@ -8,9 +8,11 @@ public class DoublePowerAction extends AbstractGameAction {
 
     @Override
     public void update() {
-        AbstractPower p = AbstractDungeon.player.powers.get(AbstractDungeon.cardRng.random(AbstractDungeon.player.powers.size() - 1));
-        p.amount *= 2;
-        p.flash();
+        if (AbstractDungeon.player.powers.size() > 0){
+            AbstractPower p = AbstractDungeon.player.powers.get(AbstractDungeon.cardRng.random(AbstractDungeon.player.powers.size() - 1));
+            p.amount *= 2;
+            p.flash();
+        }
         isDone = true;
     }
 }


### PR DESCRIPTION
Fix exception reported by amethyst:

04:18:50.782 INFO basemod.BaseMod> publish on card use
Exception: java.lang.IllegalArgumentException: n must be positive
04:18:50.900 ERROR core.CardCrawlGame> Exception caught
java.lang.IllegalArgumentException: n must be positive
    at com.badlogic.gdx.math.RandomXS128.nextLong(RandomXS128.java:110) ~[desktop-1.0.jar:?]
    at com.badlogic.gdx.math.RandomXS128.nextInt(RandomXS128.java:99) ~[desktop-1.0.jar:?]
    at com.megacrit.cardcrawl.random.Random.random(Random.java:52) ~[desktop-1.0.jar:?]
    at questionableDecisions.actions.DoublePowerAction.update(DoublePowerAction.java:11) ~[aminotunique.jar:?]
    at com.megacrit.cardcrawl.actions.GameActionManager.update(GameActionManager.java:155) ~[?:?]
    at com.megacrit.cardcrawl.rooms.AbstractRoom.update(AbstractRoom.java:279) ~[?:?]
    at com.megacrit.cardcrawl.dungeons.AbstractDungeon.update(AbstractDungeon.java:2552) ~[?:?]
    at com.megacrit.cardcrawl.core.CardCrawlGame.update(CardCrawlGame.java:878) ~[?:?]
    at com.megacrit.cardcrawl.core.CardCrawlGame.render(CardCrawlGame.java:429) [?:?]
    at com.badlogic.gdx.backends.lwjgl.LwjglApplication.mainLoop(LwjglApplication.java:225) [?:?]
    at com.badlogic.gdx.backends.lwjgl.LwjglApplication$1.run(LwjglApplication.java:126) [desktop-1.0.jar:?]
Controllers: removed manager for application, 0 managers active
Game closed.