### PR TITLE
fix attack powers

### DIFF
--- a/whoareyou/src/main/java/questionableDecisions/cards/AbstractWtfCard.java
+++ b/whoareyou/src/main/java/questionableDecisions/cards/AbstractWtfCard.java
@@ -28,6 +28,7 @@ import questionableDecisions.powers.PowerBuilder;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Random;
 
 import static com.megacrit.cardcrawl.helpers.CardLibrary.getCard;
@@ -88,12 +89,19 @@ public abstract class AbstractWtfCard extends CustomCard {
     @Override
     public void use(AbstractPlayer p, AbstractMonster m) {
         if (type == CardType.POWER) {
-            if (componentList.contains(MORECHAOSMOREPOWER.Components.WHY_DAMAGE) || componentList.contains(MORECHAOSMOREPOWER.Components.WHY_MULTI_DAMAGE)) {
+            if (componentList.contains(MORECHAOSMOREPOWER.Components.WHY_DAMAGE)) {
                 act(new ApplyPowerAction(p, p, PowerBuilder.buildPower(cardID, name, rawDescription, p, damage, false, componentList), damage));
                 return;
             }
             if (componentList.contains(MORECHAOSMOREPOWER.Components.WHY_BLOCK)) {
                 act(new ApplyPowerAction(p, p, PowerBuilder.buildPower(cardID, name, rawDescription, p, block, false, componentList), block));
+                return;
+            }
+            if (componentList.contains(MORECHAOSMOREPOWER.Components.WHY_MULTI_DAMAGE)){
+                HashMap<String, Integer> amounts = new HashMap<String, Integer>();
+                amounts.put("damage", damage);
+                amounts.put("magicNumber", magicNumber);
+                act(new ApplyPowerAction(p, p, PowerBuilder.buildPower(cardID, name, rawDescription, p, amounts, false, componentList), block));
                 return;
             }
             act(new ApplyPowerAction(p, p, PowerBuilder.buildPower(cardID, name, rawDescription, p, magicNumber, false, componentList), magicNumber));

--- a/whoareyou/src/main/java/questionableDecisions/powers/PowerBuilder.java
+++ b/whoareyou/src/main/java/questionableDecisions/powers/PowerBuilder.java
@@ -7,6 +7,8 @@ import com.megacrit.cardcrawl.localization.PowerStrings;
 import questionableDecisions.MORECHAOSMOREPOWER;
 
 import java.util.ArrayList;
+import java.util.Map;
+import java.util.MissingFormatArgumentException;
 
 import static questionableDecisions.MORECHAOSMOREPOWER.makeID;
 import static questionableDecisions.util.TextureLoader.getTexture;
@@ -26,6 +28,26 @@ public class PowerBuilder {
                 powerDesc = powerDesc.replace("!D!", "%d");
                 powerDesc = powerDesc.replace("!B!", "%d");
                 description = String.format(powerDesc, this.amount);
+            }
+        };
+        p.img = getTexture("questionableDecisionsResources/images/ui/missing_texture.png");
+        p.updateDescription();
+        return p;
+    }
+    
+    public static godpleaseendme buildPower(String ID, String name, String desc, AbstractCreature owner, Map<String, Integer> amounts, boolean reduce, ArrayList<MORECHAOSMOREPOWER.Components> c) {
+        if (!c.get(0).name().startsWith("WHEN_")) {
+            throw new RuntimeException("Wtf add a timing");
+        }
+        godpleaseendme p = new godpleaseendme(makeID(ID), name, owner, amounts, c, reduce) {
+
+            @Override
+            public void updateDescription()
+            {
+                String powerDesc = desc.replace("!M!", amounts.getOrDefault("magicNumber", 0).toString());
+                powerDesc = powerDesc.replace("!D!", amounts.getOrDefault("damage", 0).toString());
+                powerDesc = powerDesc.replace("!B!", amounts.getOrDefault("block", 0).toString());
+                description = powerDesc;
             }
         };
         p.img = getTexture("questionableDecisionsResources/images/ui/missing_texture.png");

--- a/whoareyou/src/main/java/questionableDecisions/powers/godpleaseendme.java
+++ b/whoareyou/src/main/java/questionableDecisions/powers/godpleaseendme.java
@@ -17,12 +17,14 @@ import com.megacrit.cardcrawl.monsters.AbstractMonster;
 import com.megacrit.cardcrawl.orbs.AbstractOrb;
 import com.megacrit.cardcrawl.powers.*;
 import questionableDecisions.MORECHAOSMOREPOWER;
+import questionableDecisions.MORECHAOSMOREPOWER.Components;
 import questionableDecisions.actions.ChaosTheoryAction;
 import questionableDecisions.actions.DoublePowerAction;
 import questionableDecisions.actions.RerollHandNumbersAction;
 import questionableDecisions.actions.ScaleAction;
 
 import java.util.ArrayList;
+import java.util.Map;
 
 public abstract class godpleaseendme extends AbstractPower {
     public ArrayList<MORECHAOSMOREPOWER.Components> components;
@@ -45,6 +47,20 @@ public abstract class godpleaseendme extends AbstractPower {
         this.damage = amount;
         this.block = amount;
         this.magicNumber = amount;
+        buildEffects(this.components);
+    }
+
+    public godpleaseendme(String ID, String name, AbstractCreature owner, Map<String, Integer> amounts, ArrayList<Components> components,
+            boolean reduceEachTurn) {
+        this.owner = owner;
+        this.amount = amounts.getOrDefault("amount", 0);
+        this.name = name;
+        this.ID = ID;
+        this.components = components;
+        this.reduceEachTurn = reduceEachTurn;
+        this.damage = amounts.getOrDefault("damage", 0);
+        this.block = amounts.getOrDefault("block", 0);
+        this.magicNumber = amounts.getOrDefault("magicNumber", 0);
         buildEffects(this.components);
     }
 
@@ -147,6 +163,7 @@ public abstract class godpleaseendme extends AbstractPower {
             flash();
             act(new RetainCardsAction(p, magicNumber));
         }
+        m = AbstractDungeon.getRandomMonster();
     }
 
     public void buildEffects(ArrayList<MORECHAOSMOREPOWER.Components> list) {


### PR DESCRIPTION
Fixes the crash powers with WHY_MULTI_ATTACK without many changes and while leaving room for more multi-valued powers. Also makes it so that powers switch targets after their target is dead (although now WHEN_ATTACK_WHY_DAMAGE kills everyone instead of one monster, but that's a separate matter)